### PR TITLE
Document workon alias behavior with Projects plugin

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -127,6 +127,24 @@ In the future, you may then run ``vf workon YourVirtualenv`` to simultaneously
 activate ``YourVirtualenv`` and switch to the ``/path/to/your/project``
 directory.
 
+.. note::
+
+
+    If you're using *compat_aliases* with *projects*:
+
+    1. Set ``VIRTUALFISH_COMPAT_ALIASES``
+    2. Load the ``projects`` plug-in after ``compat_aliases``.
+
+    Example:
+
+    ::
+
+        set -g VIRTUALFISH_COMPAT_ALIASES yes
+        eval (python -m virtualfish compat_aliases projects)
+
+    ``workon`` then becomes alias for ``vf workon`` instead of ``vf activate``.
+
+
 Commands
 ........
 
@@ -153,6 +171,7 @@ Configuration Variables
 
 -  ``PROJECT_HOME`` (default: ``~/projects/``) - Where to create new projects
    and where to look for existing projects.
+
 
 Environment Variables (``environment``)
 ---------------------------------------
@@ -190,7 +209,7 @@ Commands
   ``$VISUAL``/``$EDITOR`` or ``vi`` if neither variable is set.
 
 Update Python (``update_python``)
------------------------
+---------------------------------
 
 This plugin adds commands to change the python interpreter of the current
 virtual environment.


### PR DESCRIPTION
The purpose of this change is to help users understand how to get
workon` behaving similar to virtualenvwrapper's `workon` when the
`compat_aliases` and `projects` plugins are used together.

- The `compat_aliases` plug-in aliases `workon` to `vf activate`.
- The `project` plugin aliases `workon` to `vf workon`, but only
  when `VIRTUALFISH_COMPAT_ALIASES` is set when the plug-in is
  loaded.

So the order the two plugins are listed (i.e., loaded) matters,
and so does whether or not the VIRTUALFISH_COMPAT_ALIASES environment
variable is set.

If VIRTUALFISH_COMPAT_ALIASES is not set before the projects plugin is
loaded or the compat_aliases is loaded after the project plugin then
`workon` will activate the virtual environtment, but will not
automatically change to the  project directory.

See issue #137